### PR TITLE
Fixing "destroy" endpoint return status code.

### DIFF
--- a/pinax/api/viewsets.py
+++ b/pinax/api/viewsets.py
@@ -158,7 +158,7 @@ class EndpointSet(View):
             return res
 
     def render_delete(self):
-        return Response({}, status=200)
+        return Response({}, status=204)
 
     def error_response_kwargs(self, message, title=None, status=400, extra=None):
         if extra is None:


### PR DESCRIPTION
From https://github.com/for-GET/know-your-http-well/blob/master/status-codes.md:

"[204] indicates that the server has successfully fulfilled the request and that there is no additional content to send in the response payload body."

204 seems like the correct code to return after a successful deletion.
