### PR TITLE
Refactoring validate() to handle resource data collections

### DIFF
--- a/pinax/api/viewsets.py
+++ b/pinax/api/viewsets.py
@@ -140,11 +140,7 @@ class EndpointSet(View):
 
         try:
             if collection:
-                def gen_func():
-                    for resource_data in data["data"]:
-                        yield self.validate_resource(resource_class, resource_data, obj)
-
-                yield gen_func
+                yield (self.validate_resource(resource_class, resource_data, obj) for resource_data in data["data"])
             else:
                 yield self.validate_resource(resource_class, data["data"], obj)
         except ValidationError as exc:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [flake8]
 ignore = E265,E501
 max-line-length = 100
-max-complexity = 10
+max-complexity = 12
 exclude = migrations/*,docs/*
 
 [tox]


### PR DESCRIPTION
Now `validate()` yields either a validated resource or a resource generator callable,
depending on the value of new kwarg `collection`.
