### PR TITLE
Add convenience methods to EndpointSet

### DIFF
--- a/pinax/api/viewsets.py
+++ b/pinax/api/viewsets.py
@@ -9,6 +9,7 @@ import traceback
 from django.conf import settings
 from django.conf.urls import url
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db.models.base import ModelBase
 from django.http import HttpResponse, Http404
 from django.views.generic import View
 from django.views.decorators.csrf import csrf_exempt
@@ -79,8 +80,43 @@ class EndpointSet(View):
             else:
                 return self.render_error("unknown server error", status=500)
 
+    def get_pk(self):
+        """
+        Convenience method returning URL PK kwarg.
+        """
+        pk_url_kwarg = self.url.lookup["field"]
+        return self.kwargs[pk_url_kwarg] if pk_url_kwarg in self.kwargs else None
+
+    def get_resource_object_model(self):
+        """
+        Convenience method returning Resource's object model, if any.
+        """
+        if hasattr(self, "resource_class"):
+            return self.resource_class.model if hasattr(self.resource_class, "model") else None
+        else:
+            return None
+
+    def get_queryset(self):
+        """
+        Convenience method returning all Resource's object model objects.
+        """
+        return self.get_resource_object_model()._default_manager.all()
+
     def prepare(self):
-        pass
+        """
+        Sets `self.obj` to a retrieved Resource object.
+
+        No action is taken if requested method does not operate on single objects.
+
+        No action is taken if EndpointSet.get_object_model_class()
+        does not return a Django model.
+        """
+        # EndpointSets may use a different data storage than Django models.
+        # Do not assume Django models are used.
+        if isinstance(self.get_resource_object_model(), ModelBase):
+            if self.requested_method in ["retrieve", "update", "destroy"]:
+                self.pk = self.get_pk()
+                self.obj = self.get_object_or_404(self.get_queryset(), pk=self.pk)
 
     def check_authentication(self, handler):
         user = None


### PR DESCRIPTION
#### What does this PR do?

Adds commonly used code to `EndpointSet.prepare()` to retrieve a Resource object if the Resource object model is based on Django ModelBase, and if the request method is appropriate.
#### Where should the reviewer start?

Read the updated code.
#### How should this be manually tested?

Run tests.
#### Any background context you want to provide?

In another project requiring pinax-api I noticed 75% of EndpointSets use almost identical logic to obtain a Resource object via their individual `prepare()` and `get_queryset()` methods. This update aims to relieve that tedium.

`get_pk()` and `get_resource_object_model()` allow for customizing the object model and PK before object retrieval. This helps when an endpoint proxies for other models, or when a PK needs translation before object lookup.
#### What ticket or issue # does this fix?

N/A
#### Definition of Done (check if considered and/or addressed):
- [x] Is there appropriate test coverage?
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Did you update internal documentation appropriately?
- [x] Did you update (or alert the appropriate person to update) user-facing documentation?
