### PR TITLE
Add Django Model EndpointSet mixin

### DIFF
--- a/pinax/api/__init__.py
+++ b/pinax/api/__init__.py
@@ -7,6 +7,7 @@ __version__ = pkg_resources.get_distribution("pinax-api").version
 
 from . import authentication, permissions  # noqa
 from .http import Response, Redirect  # noqa
+from .mixins import DjangoModelEndpointSetMixin  #noqa
 from .registry import register, bind, registry  # noqa
 from .relationships import Relationship  # noqa
 from .resource import Resource, Attribute  # noqa

--- a/pinax/api/__init__.py
+++ b/pinax/api/__init__.py
@@ -7,7 +7,7 @@ __version__ = pkg_resources.get_distribution("pinax-api").version
 
 from . import authentication, permissions  # noqa
 from .http import Response, Redirect  # noqa
-from .mixins import DjangoModelEndpointSetMixin  #noqa
+from .mixins import DjangoModelEndpointSetMixin  # noqa
 from .registry import register, bind, registry  # noqa
 from .relationships import Relationship  # noqa
 from .resource import Resource, Attribute  # noqa

--- a/pinax/api/mixins.py
+++ b/pinax/api/mixins.py
@@ -1,4 +1,5 @@
 
+
 class DjangoModelEndpointSetMixin(object):
 
     def get_pk(self):

--- a/pinax/api/mixins.py
+++ b/pinax/api/mixins.py
@@ -1,0 +1,37 @@
+
+class DjangoModelEndpointSetMixin(object):
+
+    def get_pk(self):
+        """
+        Convenience method returning URL PK kwarg.
+        """
+        pk_url_kwarg = self.url.lookup["field"]
+        return self.kwargs[pk_url_kwarg] if pk_url_kwarg in self.kwargs else None
+
+    def get_resource_object_model(self):
+        """
+        Convenience method returning Resource's object model, if any.
+        """
+        if hasattr(self, "resource_class"):
+            return self.resource_class.model if hasattr(self.resource_class, "model") else None
+        else:
+            return None
+
+    def get_queryset(self):
+        """
+        Convenience method returning all Resource's object model objects.
+        """
+        return self.get_resource_object_model()._default_manager.all()
+
+    def prepare(self):
+        """
+        Sets `self.pk` to the requested PK
+        Sets `self.obj` to a retrieved Resource object.
+
+        Assumes Resource object is based on Django model.
+        No action is taken if requested method does not operate on single objects.
+        """
+        if self.get_resource_object_model():
+            if self.requested_method in ["retrieve", "update", "destroy"]:
+                self.pk = self.get_pk()
+                self.obj = self.get_object_or_404(self.get_queryset(), pk=self.pk)

--- a/pinax/api/tests/viewsets.py
+++ b/pinax/api/tests/viewsets.py
@@ -1,11 +1,7 @@
 
 from pinax import api
 
-from .models import (
-    Article,
-    ArticleTag,
-    Author,
-)
+from ..mixins import DjangoModelEndpointSetMixin
 from .relationships import (
     ArticleTagCollectionEndpointSet,
     ArticleAuthorEndpointSet,
@@ -18,7 +14,7 @@ from .resources import (
 
 
 @api.bind(resource=ArticleResource)
-class ArticleViewSet(api.ResourceEndpointSet):
+class ArticleViewSet(DjangoModelEndpointSetMixin, api.ResourceEndpointSet):
     """
     Handle Article retrieval.
     """
@@ -40,16 +36,6 @@ class ArticleViewSet(api.ResourceEndpointSet):
         ]
     }
 
-    def get_queryset(self):
-        return Article.objects.all()
-
-    def prepare(self):
-        if self.requested_method in ["retrieve", "update", "destroy"]:
-            self.article = self.get_object_or_404(
-                self.get_queryset(),
-                pk=self.kwargs["pk"] if "pk" in self.kwargs else None,
-            )
-
     def create(self, request):
         with self.validate(self.resource_class) as resource:
             resource.save()
@@ -69,14 +55,14 @@ class ArticleViewSet(api.ResourceEndpointSet):
         """
         Identifier: Retrieve an Article
         """
-        resource = self.resource_class(obj=self.article)
+        resource = self.resource_class(obj=self.obj)
         return self.render(resource)
 
     def update(self, request, pk):
         """
         Update an Article
         """
-        with self.validate(self.resource_class(obj=self.article)) as resource:
+        with self.validate(self.resource_class(obj=self.obj)) as resource:
             resource.save()
             return self.render(resource)
 
@@ -84,11 +70,12 @@ class ArticleViewSet(api.ResourceEndpointSet):
         """
         Delete an Article
         """
-        return super(ArticleViewSet, self).destroy(request, pk)
+        self.obj.delete()
+        return self.render_delete()
 
 
 @api.bind(resource=ArticleTagResource)
-class ArticleTagViewSet(api.ResourceEndpointSet):
+class ArticleTagViewSet(DjangoModelEndpointSetMixin, api.ResourceEndpointSet):
     """
     Handle ArticleTag retrieval.
     """
@@ -107,9 +94,6 @@ class ArticleTagViewSet(api.ResourceEndpointSet):
         ]
     }
 
-    def get_queryset(self):
-        return ArticleTag.objects.all()
-
     def list(self, request):
         """
         Identifier: List all tags
@@ -121,13 +105,12 @@ class ArticleTagViewSet(api.ResourceEndpointSet):
         """
         Identifier: Retrieve a tag
         """
-        articletag = self.get_object_or_404(self.get_queryset(), pk=pk)
-        resource = self.resource_class(articletag)
+        resource = self.resource_class(self.obj)
         return self.render(resource)
 
 
 @api.bind(resource=AuthorResource)
-class AuthorViewSet(api.ResourceEndpointSet):
+class AuthorViewSet(DjangoModelEndpointSetMixin, api.ResourceEndpointSet):
     """
     Handle Author retrieval.
     """
@@ -146,9 +129,6 @@ class AuthorViewSet(api.ResourceEndpointSet):
         ]
     }
 
-    def get_queryset(self):
-        return Author.objects.all()
-
     def list(self, request):
         """
         Identifier: List all Authors
@@ -160,6 +140,5 @@ class AuthorViewSet(api.ResourceEndpointSet):
         """
         Identifier: Retrieve an Author
         """
-        author = self.get_object_or_404(self.get_queryset(), pk=pk)
-        resource = self.resource_class(author)
+        resource = self.resource_class(self.obj)
         return self.render(resource)

--- a/pinax/api/viewsets.py
+++ b/pinax/api/viewsets.py
@@ -9,7 +9,6 @@ import traceback
 from django.conf import settings
 from django.conf.urls import url
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models.base import ModelBase
 from django.http import HttpResponse, Http404
 from django.views.generic import View
 from django.views.decorators.csrf import csrf_exempt

--- a/pinax/api/viewsets.py
+++ b/pinax/api/viewsets.py
@@ -80,43 +80,8 @@ class EndpointSet(View):
             else:
                 return self.render_error("unknown server error", status=500)
 
-    def get_pk(self):
-        """
-        Convenience method returning URL PK kwarg.
-        """
-        pk_url_kwarg = self.url.lookup["field"]
-        return self.kwargs[pk_url_kwarg] if pk_url_kwarg in self.kwargs else None
-
-    def get_resource_object_model(self):
-        """
-        Convenience method returning Resource's object model, if any.
-        """
-        if hasattr(self, "resource_class"):
-            return self.resource_class.model if hasattr(self.resource_class, "model") else None
-        else:
-            return None
-
-    def get_queryset(self):
-        """
-        Convenience method returning all Resource's object model objects.
-        """
-        return self.get_resource_object_model()._default_manager.all()
-
     def prepare(self):
-        """
-        Sets `self.obj` to a retrieved Resource object.
-
-        No action is taken if requested method does not operate on single objects.
-
-        No action is taken if EndpointSet.get_object_model_class()
-        does not return a Django model.
-        """
-        # EndpointSets may use a different data storage than Django models.
-        # Do not assume Django models are used.
-        if isinstance(self.get_resource_object_model(), ModelBase):
-            if self.requested_method in ["retrieve", "update", "destroy"]:
-                self.pk = self.get_pk()
-                self.obj = self.get_object_or_404(self.get_queryset(), pk=self.pk)
+        pass
 
     def check_authentication(self, handler):
         user = None

--- a/pinax/api/viewsets.py
+++ b/pinax/api/viewsets.py
@@ -9,6 +9,7 @@ import traceback
 from django.conf import settings
 from django.conf.urls import url
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db.models.base import ModelBase
 from django.http import HttpResponse, Http404
 from django.views.generic import View
 from django.views.decorators.csrf import csrf_exempt
@@ -79,8 +80,43 @@ class EndpointSet(View):
             else:
                 return self.render_error("unknown server error", status=500)
 
+    def get_pk(self):
+        """
+        Convenience method returning URL PK kwarg.
+        """
+        pk_url_kwarg = self.url.lookup["field"]
+        return self.kwargs[pk_url_kwarg] if pk_url_kwarg in self.kwargs else None
+
+    def get_resource_object_model(self):
+        """
+        Convenience method returning Resource's object model, if any.
+        """
+        if hasattr(self, "resource_class"):
+            return self.resource_class.model if hasattr(self.resource_class, "model") else None
+        else:
+            return None
+
+    def get_queryset(self):
+        """
+        Convenience method returning all Resource's object model objects.
+        """
+        return self.get_resource_object_model()._default_manager.all()
+
     def prepare(self):
-        pass
+        """
+        Sets `self.obj` to a retrieved Resource object.
+
+        No action is taken if requested method does not operate on single objects.
+
+        No action is taken if EndpointSet.get_object_model_class()
+        does not return a Django model.
+        """
+        # EndpointSets may use a different data storage than Django models.
+        # Do not assume Django models are used.
+        if isinstance(self.get_resource_object_model(), ModelBase):
+            if self.requested_method in ["retrieve", "update", "destroy"]:
+                self.pk = self.get_pk()
+                self.obj = self.get_object_or_404(self.get_queryset(), pk=self.pk)
 
     def check_authentication(self, handler):
         user = None


### PR DESCRIPTION
#### What does this PR do?

Creates mixin with commonly used code for `EndpointSet.prepare()` to retrieve a Django Model-based Resource object, if the request method is appropriate.
#### Where should the reviewer start?

Read the mixin code.
#### How should this be manually tested?

No tests yet for the mixin.
#### Any background context you want to provide?

See https://github.com/pinax/pinax-api/pull/10
#### What ticket or issue # does this fix?

N/A
#### Definition of Done (check if considered and/or addressed):
- [x] Is there appropriate test coverage?

Yes, updated test case ResourceEndpointSets to use new DjangoModelEndpointSetMixin.
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Did you update internal documentation appropriately?
- [x] Did you update (or alert the appropriate person to update) user-facing documentation?
