### PR TITLE
Auto model pk lookup

### DIFF
--- a/pinax/api/mixins.py
+++ b/pinax/api/mixins.py
@@ -32,7 +32,10 @@ class DjangoModelEndpointSetMixin(object):
         Assumes Resource object is based on Django model.
         No action is taken if requested method does not operate on single objects.
         """
-        if self.get_resource_object_model():
+        resource_model = self.get_resource_object_model()
+        if resource_model:
             if self.requested_method in ["retrieve", "update", "destroy"]:
                 self.pk = self.get_pk()
-                self.obj = self.get_object_or_404(self.get_queryset(), pk=self.pk)
+                # Use the model primary key field name
+                kwargs = {resource_model._meta.pk.name: self.pk}
+                self.obj = self.get_object_or_404(self.get_queryset(), **kwargs)

--- a/pinax/api/tests/models.py
+++ b/pinax/api/tests/models.py
@@ -19,6 +19,9 @@ class Article(models.Model):
 
 
 class ArticleTag(models.Model):
+
+    custom_pk = models.AutoField(primary_key=True)
+
     article = models.ForeignKey(Article)
     name = models.CharField(max_length=50)
 

--- a/pinax/api/tests/test.py
+++ b/pinax/api/tests/test.py
@@ -3,6 +3,8 @@ from django.test import TestCase as BaseTestCase
 
 class TestCase(BaseTestCase):
 
+    maxDiff = None
+
     def assertResourceGraphEqual(self, a, b):
         """
         Compare two lists of JSON:API resources.

--- a/pinax/api/tests/test_pagination.py
+++ b/pinax/api/tests/test_pagination.py
@@ -61,7 +61,6 @@ class TestPagination(TestCase):
             "linkage": False
         }
         top_level = TopLevel(**data)
-        article_tags_url = reverse("article-tags-relationship-detail", kwargs=dict(pk=item1.pk))
         expected = {
             "jsonapi": {"version": "1.0"},
             "meta": {
@@ -79,15 +78,9 @@ class TestPagination(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": "{}".format(article_tags_url)
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=item1.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(author.pk)
@@ -138,15 +131,9 @@ class TestPagination(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=item1.pk))
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=item1.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(author.pk)
@@ -162,15 +149,9 @@ class TestPagination(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=item2.pk))
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=item2.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(author.pk)
@@ -186,15 +167,9 @@ class TestPagination(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=item3.pk))
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=item3.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(author.pk)
@@ -257,15 +232,9 @@ class TestPaginationPageSize(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(self.author.pk)
@@ -281,15 +250,9 @@ class TestPaginationPageSize(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item2.pk))
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item2.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(self.author.pk)
@@ -305,15 +268,9 @@ class TestPaginationPageSize(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item3.pk))
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item3.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(self.author.pk)
@@ -323,7 +280,6 @@ class TestPaginationPageSize(TestCase):
                 }
             ]
         }
-        payload = self.top_level.serializable(request=self.request)
 
         self.assertResourceGraphEqual(
             expected.pop("data"),
@@ -356,15 +312,9 @@ class TestPaginationPageSize(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(self.author.pk)
@@ -410,15 +360,9 @@ class TestPaginationPageSize(TestCase):
                         },
                         "relationships": {
                             "tags": {
-                                "links": {
-                                    "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                                },
                                 "data": []
                             },
                             "author": {
-                                "links": {
-                                    "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                                },
                                 "data": {
                                     "type": "author",
                                     "id": str(self.author.pk)
@@ -434,15 +378,9 @@ class TestPaginationPageSize(TestCase):
                         },
                         "relationships": {
                             "tags": {
-                                "links": {
-                                    "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item2.pk))
-                                },
                                 "data": []
                             },
                             "author": {
-                                "links": {
-                                    "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item2.pk))
-                                },
                                 "data": {
                                     "type": "author",
                                     "id": str(self.author.pk)
@@ -479,15 +417,9 @@ class TestPaginationPageSize(TestCase):
                         },
                         "relationships": {
                             "tags": {
-                                "links": {
-                                    "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                                },
                                 "data": []
                             },
                             "author": {
-                                "links": {
-                                    "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                                },
                                 "data": {
                                     "type": "author",
                                     "id": str(self.author.pk)
@@ -503,15 +435,9 @@ class TestPaginationPageSize(TestCase):
                         },
                         "relationships": {
                             "tags": {
-                                "links": {
-                                    "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item2.pk))
-                                },
                                 "data": []
                             },
                             "author": {
-                                "links": {
-                                    "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item2.pk))
-                                },
                                 "data": {
                                     "type": "author",
                                     "id": str(self.author.pk)
@@ -527,15 +453,9 @@ class TestPaginationPageSize(TestCase):
                         },
                         "relationships": {
                             "tags": {
-                                "links": {
-                                    "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item3.pk))
-                                },
                                 "data": []
                             },
                             "author": {
-                                "links": {
-                                    "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item3.pk))
-                                },
                                 "data": {
                                     "type": "author",
                                     "id": str(self.author.pk)
@@ -613,15 +533,9 @@ class TestPaginationPageNumber(TestCase):
                     },
                     "relationships": {
                         "tags": {
-                            "links": {
-                                "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                            },
                             "data": []
                         },
                         "author": {
-                            "links": {
-                                "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item1.pk))
-                            },
                             "data": {
                                 "type": "author",
                                 "id": str(self.author.pk)
@@ -665,15 +579,9 @@ class TestPaginationPageNumber(TestCase):
                         },
                         "relationships": {
                             "tags": {
-                                "links": {
-                                    "self": reverse("article-tags-relationship-detail", kwargs=dict(pk=self.item3.pk))
-                                },
                                 "data": []
                             },
                             "author": {
-                                "links": {
-                                    "self": reverse("article-author-relationship-detail", kwargs=dict(pk=self.item3.pk))
-                                },
                                 "data": {
                                     "type": "author",
                                     "id": str(self.author.pk)

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,16 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.9,master},
-    py34-{1.9,master},
-    py35-{1.9,master}
+    py27-{1.9,1.10,master},
+    py34-{1.9,1.10,master},
+    py35-{1.9,1.10,master}
 
 [testenv]
 deps =
     coverage == 4.0.2
     flake8 == 2.5.0
     1.9: Django>=1.9,<1.10
+    1.10: Django>=1.10,<1.11
     master: https://github.com/django/django/tarball/master
 usedevelop = True
 setenv =


### PR DESCRIPTION
Determine and use primary key field name when retrieving Django model instances.

Updates tests to remove "links", this should be verified as desirable JSON result.
